### PR TITLE
Sets @types/bluebird dependency to version 3.5.21 to fix build failures.

### DIFF
--- a/loaner/package.json
+++ b/loaner/package.json
@@ -28,6 +28,7 @@
     "@angular/platform-browser": "6.0.0-rc.6",
     "@angular/platform-browser-dynamic": "6.0.0-rc.6",
     "@angular/router": "6.0.0-rc.6",
+    "@types/bluebird": "3.5.21",
     "core-js": "2.5.1",
     "es6-shim": "0.35.3",
     "hammerjs": "2.0.8",


### PR DESCRIPTION
PiperOrigin-RevId: 204780987